### PR TITLE
add actions to automatically create a new tag and release after every commit to master

### DIFF
--- a/.github/workflows/auto-release-notes.yml
+++ b/.github/workflows/auto-release-notes.yml
@@ -1,0 +1,23 @@
+
+name: "auto-release-notes"
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  tagged-release:
+    name: "auto-release-notes"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      # ...
+      - name: "Build & test"
+        run: |
+          echo "done!"
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.ACCESS_TOKEN }}"
+          prerelease: false

--- a/.github/workflows/bump-tag.yml
+++ b/.github/workflows/bump-tag.yml
@@ -1,0 +1,16 @@
+
+name: bump-tag
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Github Tag Bump
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        DEFAULT_BUMP: patch

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ This library contains react component used in Admin Portal and Admin Portal Exte
     yarn storybook
     ```
 
+## How to commit?
+Currently we have two GitHub actions that will automatically create a new tag and a new release everytime a commit is merged to master branch. 
+Things you should pay attention to before merging your work to master branch :
+- Make sure to update `CHANGELOG.md` to keep track on what's updated in the repo
+- If you want to update the minor version, add `#minor` at the end of your commit message (ex: `fix(some_component): some message #minor`)
+- The same goes if you want to update the major version, add `#major` at the end of your commit message
+- If you don't add one of those two to your commit message, the Github actions will update the patch version
+- But if you don't want to update the version, you can add `#none` at the end of your commit message so that the actions won't create any new tag
+
 ## When to add?
 You need common component for both AP and AP Extension
 
@@ -26,6 +35,3 @@ You need common component for both AP and AP Extension
 - Upgrade justice-ui-library in AP
 - Refactor component import from AP to justice-ui-library
 - Remove component in AP once all the component imported from justice-ui-library
-
-## Note
-- CHANGELOG.md should be updated in every commit to master to keep track on what's updated in the repo


### PR DESCRIPTION
to get this to work, someone with admin access to this repo to :
- set an access token from Account Settings > Developer Settings > Personal access tokens > Generate new token
- go to repo settings > Secrets > New repository secret
- set an env var with name=ACCESS_TOKEN and the value of the previously generated access token